### PR TITLE
Fix: changed default endpoint value

### DIFF
--- a/src/main/resources/conf.properties
+++ b/src/main/resources/conf.properties
@@ -15,6 +15,6 @@
 #
 
 type = dummy
-endpoint = http://localhost:8081
+endpoint = http://vnfm-dummy-rest:8081
 endpoint-type = REST
 allocate = false


### PR DESCRIPTION
The endpoint url has to be configured anyhow, so as a workaround for docker containers in a compose environment provided by our .yml this fixes the loopback to localhost.